### PR TITLE
FIX: remove unfinished function in UniswapFlashQuery.sol

### DIFF
--- a/simple_arbitrage/contracts/UniswapFlashQuery.sol
+++ b/simple_arbitrage/contracts/UniswapFlashQuery.sol
@@ -53,14 +53,4 @@ contract FlashBotsUniswapQuery {
         return result;
     }
 
-    function getTokenPricesInWeth(address[] calldata _tokens, uint256[] _amountsIn) external view returns (uint256[] memory) {
-
-        uint256[] memory result = new uint256[](_tokens.length);
-
-        for (uint i =0; i < _tokens.length; i++) {
-
-            result[i] = IUniswapV2Router01
-        }
-    }
-
 }


### PR DESCRIPTION
removed getTokenPricesInWeth because the function is not finished and the contract fails to compile